### PR TITLE
[DEPENDENCY] - Bump Action runner to Node16 from Node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Currently Github Actions is running this with `Node16` by default and throwing a warning. 

![image](https://github.com/ndepend/ndepend-action/assets/46493523/b3feca7a-7e35-400d-8531-ed29bb5e0b2a)

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default

Bumping this should clear the warning in the action result. 